### PR TITLE
Use UTF-8 encoding when reading README.rst in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ extens = [Extension('backports.lzma._lzma',
 descr = "Backport of Python 3.3's 'lzma' module for XZ/LZMA compressed files."
 
 # Load in our reStructuredText README.rst file to pass explicitly in the metadata
-with open("README.rst") as handle:
+with open("README.rst", encoding="UTF-8") as handle:
     long_descr = handle.read()
 
 if sys.version_info < (2,6):


### PR DESCRIPTION
Without this specified, the encoding is system dependent. On some systems (for example, many Docker containers), this ends up as ASCII, and throws an Exception because of the non-ascii names in this file.
Before:
```
root@8e2e1f515426:/tmp/backports.lzma-0.0.11# python3 setup.py install
This is backports.lzma version 0.0.11
Traceback (most recent call last):
  File "setup.py", line 77, in <module>
    long_descr = handle.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 7390: ordinal not in range(128)
```

After:
```
root@8e2e1f515426:/tmp/backports.lzma-0.0.11# python3 setup.py install
This is backports.lzma version 0.0.11
running install
running build
running build_py
creating build
creating build/lib.linux-x86_64-3.6
<etc>
```